### PR TITLE
Copyright info update + Client ready in stat

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 YorkAARGH
+Copyright (c) 2022 The Skill Tree Project Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/commands/stats.js
+++ b/commands/stats.js
@@ -11,6 +11,7 @@ exports.run = (client, message, args, level) => { // eslint-disable-line no-unus
   • Users      :: ${client.guilds.cache.map(g => g.memberCount).reduce((a, b) => a + b).toLocaleString()}
   • Servers    :: ${client.guilds.cache.size.toLocaleString()}
   • Channels   :: ${client.channels.cache.size.toLocaleString()}
+  • Last Ready :: ${client.readyAt}
   • Discord.js :: v${version}
   • Node       :: ${process.version}`);
   message.channel.send(stats);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged, as well as any and all proof of successful tests:**

Updated copyright information in LICENSE

Added a last client ready time to the stats command. This could be useful while debugging bot commands, as it allows you to make sure that previous updates were pushed.

**Semantic versioning classification:**

- [x] This PR changes the framework's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to README, etc.
